### PR TITLE
Misc updates

### DIFF
--- a/broccoli-elm/index.js
+++ b/broccoli-elm/index.js
@@ -7,6 +7,10 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const moduleNoise = require('./module-noise')
 
+const optionDefaults = {
+  yes: true
+}
+
 module.exports = class ElmCompiler extends CachingWriter {
 
   /**
@@ -15,16 +19,18 @@ module.exports = class ElmCompiler extends CachingWriter {
    * `this.outputPath`, which is computed by a parent class.
    */
 
-  constructor(inputNodes, destDir = '') {
+  constructor(inputNodes, destDir = '', options = {}) {
     super(inputNodes, {
       name: 'ElmCompiler',
       annotation: 'broccoli-elm',
       persistentOutput: false,
       cacheInclude: [/.*\.elm$/],
       cacheExclude: []
-    })
+    });
 
-    this.destDir = destDir
+    this.destDir = destDir;
+    let useDebug = process.env.EMBER_ENV != 'production';
+    this.options = Object.assign({debug: useDebug}, optionDefaults, options);
   }
 
   /**
@@ -34,7 +40,8 @@ module.exports = class ElmCompiler extends CachingWriter {
    */
 
   build() {
-    return compileToString(this.listFiles(), { yes: true }).then(data => {
+    let options = Object.assign({}, this.options);
+    return compileToString(this.listFiles(), options).then(data => {
       // elm-make output
       let d = data.toString()
 
@@ -73,7 +80,7 @@ module.exports = class ElmCompiler extends CachingWriter {
       // make error red
       err.message = chalk.red(err.message)
 
-      throw err
+      throw err;
     })
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,19 +3,23 @@ const ElmCompiler = require('./broccoli-elm')
 const BroccoliMergeTrees = require('broccoli-merge-trees')
 
 class ElmPlugin {
-  constructor() {
-    this.name = 'ember-elm'
-    this.ext = 'elm'
+  constructor(options) {
+    this.name = 'ember-elm';
+    this.ext = 'elm';
+    this.options = options;
   }
 
-  toTree(tree, inputPath, outputPath, options) {
+  toTree(tree, inputPath, outputPath) {
+    // Ignore elm outside of the main app, so we don't try to compile tests.
+    if (inputPath != '/') {
+      return tree;
+    }
     // tree.destDir is undefined when tree is a BroccoliMergeTree.
     // So we use outputPath instead, which seems to work.
-    const destDir = tree.destDir || outputPath
-
-    const jsTree = tree
-    const elmTree = new ElmCompiler([tree], destDir)
-    return new BroccoliMergeTrees([jsTree, elmTree])
+    const destDir = tree.destDir || outputPath;
+    const jsTree = tree;
+    const elmTree = new ElmCompiler([tree], destDir, this.options);
+    return new BroccoliMergeTrees([jsTree, elmTree]);
   }
 }
 
@@ -29,6 +33,8 @@ module.exports = {
   name: 'ember-elm',
 
   setupPreprocessorRegistry(type, registry) {
-    registry.add('js', new ElmPlugin)
+    let options = this.options || {}
+    let elmOptions = options.elm;
+    registry.add('js', new ElmPlugin(elmOptions));
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-elm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Write Elm in your Ember app",
   "keywords": [
     "ember-addon",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,13 +49,13 @@ ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-regex@*, ansi-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
-
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
+
+ansi-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -1139,7 +1139,7 @@ debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   dependencies:
     ms "0.7.2"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -2375,7 +2375,7 @@ iferr@^0.1.5, iferr@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -2785,10 +2785,6 @@ lodash._basefor@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -2796,13 +2792,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -2812,17 +2804,11 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -2941,7 +2927,7 @@ lodash.omit@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -3786,7 +3772,7 @@ readable-stream@~2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -4550,7 +4536,7 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
@nucleartide This adds the ability to set options for elm-make, and enables debug mode by default when not doing a production build. It also tries to only compile .elm files from the main app, which is useful when using elm-test in a project, since compiling the tests usually fails during the application build process.