### PR TITLE
Fix option loading, and don't register complier for the addon itself.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 const ElmCompiler = require('./broccoli-elm')
 const BroccoliMergeTrees = require('broccoli-merge-trees')
 
@@ -33,8 +32,12 @@ module.exports = {
   name: 'ember-elm',
 
   setupPreprocessorRegistry(type, registry) {
-    let options = this.options || {}
-    let elmOptions = options.elm;
-    registry.add('js', new ElmPlugin(elmOptions));
+    // No need to try to compile elm within the addon
+    if (type == 'parent') {
+      let app = this.app || this;
+      let options = app.options || {};
+      let elmOptions = options.elm;
+      registry.add('js', new ElmPlugin(elmOptions));
+    }
   }
 }


### PR DESCRIPTION
I hit some issues loading options from our app's `ember-cli-build.js`, which I belive was working before. Not sure if something changed in newer versions of ember or if this was always broken.

I also stopped the preprocessor from registering for building the addon itself, since there's no actual elm code in the addon. That prevents build failures when the path to `elm-make` is configured in the parent application. The `self` registry doesn't see the `elm-make` path option, and fails when elm isn't installed globally, even though there are no actual files to compile.