### PR TITLE
Fix build for no Elm files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Unreleased]
 ==================
   * Update ember version to 3.4.8
+  * Fix build with no Elm files
 
 v0.3.0 / 2018-09-23
 ==================

--- a/broccoli-elm/index.js
+++ b/broccoli-elm/index.js
@@ -44,13 +44,16 @@ module.exports = class ElmCompiler extends CachingWriter {
 
   build() {
     let options = Object.assign({}, this.options);
-    return compileToString(this.listFiles(), options)
+    let files = this.listFiles();
+    if (!files.length) {
+      // Nothing to build
+      return;
+    }
+
+    return compileToString(files, options)
       .then(data => {
         // elm-make output
         let jsStr = data.toString();
-
-        // if there are no Elm files to compile, do nothing
-        if (!jsStr) return;
 
         // fix module exports
         jsStr =


### PR DESCRIPTION
The check for no elm files is too late. Elm compiler will fail if it is fed with nothing. 