### PR TITLE
Upgrade to elm 0.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "8"
 
 sudo: false
+os: linux
 dist: trusty
 
 addons:
@@ -37,11 +38,14 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-    - env: EMBER_TRY_SCENARIO=ember-release
-    - env: EMBER_TRY_SCENARIO=ember-beta
-    - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - stage: "Additional Tests (ember-release)"
+      env: EMBER_TRY_SCENARIO=ember-release
+    - stage: "Additional Tests (ember-beta)"
+      env: EMBER_TRY_SCENARIO=ember-beta
+    - stage: "Additional Tests (ember-canary)"
+      env: EMBER_TRY_SCENARIO=ember-canary
+    - stage: "Additional Tests (ember-default-with-jquery)"
+      env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 before_install:
   - npm config set spin false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -38,8 +38,6 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ import Elm from 'my-app/elm-modules'
 export default Ember.Route.extend({
   setupController(controller, model) {
     controller.set('Elm', Elm)
-  } 
+  }
 })
 ```
 
@@ -156,6 +156,32 @@ export default Ember.Controller.extend({
 ```
 
 ## Notes
+
+### main
+
+Compilation of Elm files in version 0.19.1 requires a `main` value for all files
+passed to `elm-make`.
+
+```
+-- NO MAIN ---------------------------------------------------------------------
+
+When producing a JS file, I require that given files all have `main` values.
+That way functions like Elm.CSS.ChatConversationStyle.init() are definitely
+defined in the resulting file. I am missing `main` values in:
+
+... cut for brevity ...
+```
+
+To target only files that have `main` values, use the ember-elm `includePaths`
+configuration option in `ember-cli-build.js` to limited compliation to only
+safe directories.  The elm compiler will handle including any other module
+dependencies.
+
+```js
+elm: {
+  includePaths: ['app/elm-modules/Main']
+}
+```
 
 ### elm-stuff
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ defined in the resulting file. I am missing `main` values in:
 ```
 
 To target only files that have `main` values, use the ember-elm `includePaths`
-configuration option in `ember-cli-build.js` to limited compliation to only
+configuration option in `ember-cli-build.js` to limit compliation to only
 safe directories.  The elm compiler will handle including any other module
 dependencies.
 

--- a/broccoli-elm/index.js
+++ b/broccoli-elm/index.js
@@ -68,8 +68,11 @@ module.exports = class ElmCompiler extends CachingWriter {
         fs.writeFileSync(path.join(dir, "elm-modules.js"), jsStr);
       })
       .catch(err => {
-        // make error cleaner
-        err.message = formatMessage(err.message);
+        if (err.message) {
+
+          // make error cleaner
+          err.message = formatMessage(err.message);
+        }
 
         throw err;
       });

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,30 +11,6 @@ module.exports = function() {
     return {
       scenarios: [
         {
-          name: 'ember-lts-2.16',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.16.0'
-            }
-          }
-        },
-        {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0'
-            }
-          }
-        },
-        {
           name: 'ember-release',
           npm: {
             devDependencies: {

--- a/elm.json
+++ b/elm.json
@@ -1,20 +1,20 @@
 {
     "type": "application",
     "source-directories": [
-        "."
+        "tests/dummy/app/elm-modules"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.2",
             "elm/html": "1.0.0"
         },
         "indirect": {
-            "elm/json": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.2"
         }
     },
     "test-dependencies": {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,7 @@ const EmberAddon = require("ember-cli/lib/broccoli/ember-addon");
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     elm: {
-      includePath: 'tests/dummy/app/elm-modules/Main'
+      includePaths: ['tests/dummy/app/elm-modules/Main']
     }
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,7 +3,11 @@
 const EmberAddon = require("ember-cli/lib/broccoli/ember-addon");
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {});
+  var app = new EmberAddon(defaults, {
+    elm: {
+      includePath: 'tests/dummy/app/elm-modules/Main'
+    }
+  });
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const ElmCompiler = require("./broccoli-elm");
 const BroccoliMergeTrees = require("broccoli-merge-trees");
 
 var defaultOptions = {
-  includePath: undefined
+  includePaths: []
 };
 
 class ElmPlugin {
@@ -24,19 +24,19 @@ class ElmPlugin {
       return tree;
     }
 
-    var elmTargets = tree;
-    if (this.options.includePath) {
-      elmTargets = this.options.includePath;
+    var elmTargets = [tree];
+    if (this.options.includePaths.length > 0) {
+      elmTargets = this.options.includePaths;
     }
 
     var elmOptions = Object.assign({}, this.options);
-    delete elmOptions.includePath;
+    delete elmOptions.includePaths;
 
     // tree.destDir is undefined when tree is a BroccoliMergeTree.
     // So we use outputPath instead, which seems to work.
     const destDir = tree.destDir || outputPath;
     const jsTree = tree;
-    const elmTree = new ElmCompiler([elmTargets], destDir, elmOptions);
+    const elmTree = new ElmCompiler(elmTargets, destDir, elmOptions);
     return new BroccoliMergeTrees([jsTree, elmTree]);
   }
 }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,24 @@ module.exports = {
       let app = this.app || this;
       let options = app.options || {};
       let elmOptions = options.elm || {};
+
+      // We need to make sure ember-cli-babel runs after the elm compilation
+      // because it wraps the compilation output in the AMD module loader.
+      // Likely all preprocessors need to run after elm compilation , so we move them all to the back to the line.
+      // WARNING: in some projects ember-cli-babel gets added to the js registry
+      // by default, giving the impression this isn't needed.  These lines are for projects that aren't so lucky.
+      let existingPreprocessors = registry.registeredForType('js');
+
+      // registeredForType returns the internal copy, that would get mutated
+      // by the lines below.
+      let preprocessorsBeforeElm = existingPreprocessors.slice(0);
+      preprocessorsBeforeElm.forEach(preprocessor =>
+          registry.remove('js', preprocessor)
+      );
       registry.add("js", new ElmPlugin(elmOptions));
+      preprocessorsBeforeElm.forEach(preprocessor =>
+          registry.add('js', preprocessor)
+      );
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -3,11 +3,19 @@
 const ElmCompiler = require("./broccoli-elm");
 const BroccoliMergeTrees = require("broccoli-merge-trees");
 
+var defaultOptions = {
+  includePath: undefined
+};
+
 class ElmPlugin {
   constructor(options) {
     this.name = "ember-elm";
     this.ext = "elm";
-    this.options = options;
+    this.options = Object.assign(
+      {},
+      defaultOptions,
+      options
+    );
   }
 
   toTree(tree, inputPath, outputPath) {
@@ -15,11 +23,20 @@ class ElmPlugin {
     if (inputPath != "/") {
       return tree;
     }
+
+    var elmTargets = tree;
+    if (this.options.includePath) {
+      elmTargets = this.options.includePath;
+    }
+
+    var elmOptions = Object.assign({}, this.options);
+    delete elmOptions.includePath;
+
     // tree.destDir is undefined when tree is a BroccoliMergeTree.
     // So we use outputPath instead, which seems to work.
     const destDir = tree.destDir || outputPath;
     const jsTree = tree;
-    const elmTree = new ElmCompiler([tree], destDir, this.options);
+    const elmTree = new ElmCompiler([elmTargets], destDir, elmOptions);
     return new BroccoliMergeTrees([jsTree, elmTree]);
   }
 }
@@ -38,7 +55,7 @@ module.exports = {
     if (type == "parent") {
       let app = this.app || this;
       let options = app.options || {};
-      let elmOptions = options.elm;
+      let elmOptions = options.elm || {};
       registry.add("js", new ElmPlugin(elmOptions));
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
-    "elm": "^0.19.0-bugfix6",
+    "elm": "^0.19.1-3",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.4.0",
     "ember-cli-app-version": "^2.0.0",
@@ -64,7 +64,7 @@
     "qunit-dom": "^0.8.4"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/elm-modules/Hello/Jason.elm
+++ b/tests/dummy/app/elm-modules/Hello/Jason.elm
@@ -1,5 +1,0 @@
-module Hello.Jason exposing (hello)
-
-
-hello =
-    "jason"

--- a/tests/dummy/app/elm-modules/Hello/Jesse.elm
+++ b/tests/dummy/app/elm-modules/Hello/Jesse.elm
@@ -1,5 +1,0 @@
-module Hello.Jesse exposing (hello)
-
-
-hello =
-    "jesse"

--- a/tests/dummy/app/elm-modules/Hello/Label.elm
+++ b/tests/dummy/app/elm-modules/Hello/Label.elm
@@ -1,0 +1,4 @@
+module Hello.Label exposing (text)
+
+text =
+    "Send"

--- a/tests/dummy/app/elm-modules/Main/Chat.elm
+++ b/tests/dummy/app/elm-modules/Main/Chat.elm
@@ -1,9 +1,10 @@
-port module Chat exposing (main)
+port module Main.Chat exposing (main)
 
 import Browser
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Hello.Label
 
 
 main =
@@ -73,11 +74,9 @@ port emoji : (String -> msg) -> Sub msg
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Sub.none
+    emoji NewEmoji
 
 
-
--- Sub.batch [ WS.listen server NewMessage, emoji NewEmoji ]
 --
 -- View.
 --
@@ -87,7 +86,7 @@ view : Model -> Html Msg
 view model =
     div [ class "chat-container" ]
         [ input [ class "chat-message-input", onInput Input, value model.input ] []
-        , button [ onClick Send ] [ text "Send" ]
+        , button [ onClick Send ] [ text Hello.Label.text ]
         , div [ class "chat-messages" ] (List.map viewMessage (List.reverse model.messages))
         ]
 

--- a/tests/dummy/app/elm-modules/Main/Hello.elm
+++ b/tests/dummy/app/elm-modules/Main/Hello.elm
@@ -1,4 +1,4 @@
-module Hello exposing (main)
+module Main.Hello exposing (main)
 
 import Html exposing (text)
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -10,6 +10,6 @@
     </button>
 
     <h2>This is an Elm component.</h2>
-    {{elm-component src=Elm.Chat flags=flags setup=(route-action "setup ports")}}
+    {{elm-component src=Elm.Main.Chat flags=flags setup=(route-action "setup ports")}}
   </div>
 </div>

--- a/tests/integration/components/elm-component-test.js
+++ b/tests/integration/components/elm-component-test.js
@@ -11,7 +11,7 @@ module("Integration | Component | elm component", function(hooks) {
   test("it works", async function(assert) {
     const done = assert.async();
     this.set("Elm", Elm);
-    await render(hbs`{{elm-component src=Elm.Hello}}`);
+    await render(hbs`{{elm-component src=Elm.Main.Hello}}`);
 
     run.next(() => {
       assert.dom(this.element).hasText("hello world");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,29 +1674,10 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-binary@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
-  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
-  dependencies:
-    buffers "~0.1.1"
-    chainsaw "~0.1.0"
-
 "binaryextensions@1 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
   integrity sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==
-
-binwrap@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/binwrap/-/binwrap-0.2.0.tgz#572d0f48c4e767d72d622f0b805ed7ce1db16f9a"
-  integrity sha512-HUspivC8zPE37KJQ0S4zsNHUpymzQBinmpdMoa+JwmB6Mi+p30ywVZJcillYpbQmiX2wLykaaDJxXmwZkbaZGA==
-  dependencies:
-    mustache "^2.3.0"
-    request "^2.87.0"
-    request-promise "^4.2.0"
-    tar "^2.2.1"
-    unzip-stream "^0.3.0"
 
 blank-object@^1.0.1:
   version "1.0.2"
@@ -1708,14 +1689,7 @@ blob@0.0.4:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
   integrity sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
-
-bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.0:
+bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
   integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
@@ -2329,11 +2303,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffers@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
-  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -2458,13 +2427,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chainsaw@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
-  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
-  dependencies:
-    traverse ">=0.3.0 <0.4"
 
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
@@ -2838,15 +2800,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-spawn@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.0.tgz#8254774ab4786b8c5b3cf4dfba66ce563932c252"
-  integrity sha1-glR3SrR4a4xbPPTfumbOVjkywlI=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -3090,12 +3044,12 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.67.tgz#5e8f3ffac89b4b0402c7e1a565be06f3a109abbc"
   integrity sha512-h3zEBLdHvsKfaXv1SHAtykJyNtwYFEKkrWGSFyW1BzGgPQ4ykAzD5Hd8C5MZGTAEhkCKmtyIwYUrapsI0xfKww==
 
-elm@^0.19.0-bugfix6:
-  version "0.19.0-bugfix6"
-  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.0-bugfix6.tgz#ebba8a9a57346b0abf96f36231df51999d9ecc53"
-  integrity sha512-nD/oK/nG26ULh94GREsILA9aQa3Gon+KKBmS0Z0MstywLWwrhuWKba8gfiIWLdnpQWHFIf+UsThk6Z71UWi6TQ==
+elm@^0.19.1-3:
+  version "0.19.1-3"
+  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1-3.tgz#2382aa1943bc79974b5d95b0a6acbe010ee16909"
+  integrity sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==
   dependencies:
-    binwrap "0.2.0"
+    request "^2.88.0"
 
 ember-ajax@^3.1.0:
   version "3.1.3"
@@ -4280,13 +4234,13 @@ find-babel-config@^1.1.0:
     json5 "^0.5.1"
     path-exists "^3.0.0"
 
-find-elm-dependencies@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-elm-dependencies/-/find-elm-dependencies-2.0.0.tgz#435aa05a6544a0ecf54c5d1ac85cc1ca1044e4e4"
-  integrity sha512-lnLilxwdS3U/CSPoMnfUL1u21MBNolv6NF54y4Yds7WxdRMrTBXrmugrcvIGvakWQ2anYuinmBSUR+jUQy+vpA==
+find-elm-dependencies@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/find-elm-dependencies/-/find-elm-dependencies-2.0.2.tgz#589a759a021e6e2f8f0df805f973313fc4b55693"
+  integrity sha512-nM5UCbccD1G8CGK2GsM7ykG3ksOAl9E+34jiDfl07CAl2OPnLpBVWY2hlxEmIkSBfdJjSopEowWHrO0cI8RhxQ==
   dependencies:
     firstline "1.2.0"
-    lodash "4.17.10"
+    lodash "4.17.15"
 
 find-index@^1.1.0:
   version "1.1.0"
@@ -4537,16 +4491,6 @@ fsevents@^1.2.3:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
-
-fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5103,7 +5047,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -6105,12 +6049,12 @@ lodash.values@~2.3.0:
   dependencies:
     lodash.keys "~2.3.0"
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6151,14 +6095,6 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
-
-lru-cache@^4.0.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
-  integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
 
 make-array@^0.1.2:
   version "0.1.2"
@@ -6408,7 +6344,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -6457,11 +6393,6 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-mustache@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
-  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
 
 mustache@^3.0.0:
   version "3.0.0"
@@ -6541,14 +6472,14 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-elm-compiler@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-5.0.1.tgz#d62094ee72d6aad616ebaa71397b6cfac90381f6"
-  integrity sha512-Li9NfZTL83/URoUEWly+iHJeOcZRBYUaeIL4MImnB4r21oe/xpkR6JRHjdNjLf1rMtO0tgPyOvuGW4Beytaaow==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-5.0.4.tgz#e139c517c4b91f914cccb0a06e3329e3c49d02ac"
+  integrity sha512-VQsT8QSierYGkHzRed+b4MnccQVF1+qPHunE8jBoU7jD6YpuRqCDPzEoC2zfyEJS80qVnlMZrqobLnyjzX9lJg==
   dependencies:
-    cross-spawn "4.0.0"
-    find-elm-dependencies "2.0.0"
-    lodash "4.17.10"
-    temp "^0.8.3"
+    cross-spawn "6.0.5"
+    find-elm-dependencies "2.0.2"
+    lodash "4.17.15"
+    temp "^0.9.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -7119,11 +7050,6 @@ proxy-addr@~2.0.3, proxy-addr@~2.0.4:
     forwarded "~0.1.2"
     ipaddr.js "1.8.0"
 
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-
 psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
@@ -7460,24 +7386,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
-  dependencies:
-    lodash "^4.13.1"
-
-request-promise@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
-  integrity sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
-
-request@^2.87.0:
+request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -7580,19 +7489,19 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@2.6.3, rimraf@^2.6.2:
+rimraf@2.6.3, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+  dependencies:
+    glob "^7.0.5"
 
 rimraf@~2.2.6:
   version "2.2.8"
@@ -8120,11 +8029,6 @@ statuses@~1.4.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
   integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
-stealthy-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -8264,15 +8168,6 @@ tap-parser@^7.0.0:
     js-yaml "^3.2.7"
     minipass "^2.2.0"
 
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
-
 tar@^4:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -8286,13 +8181,20 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-temp@0.8.3, temp@^0.8.3:
+temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
   integrity sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+temp@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.1.tgz#2d666114fafa26966cd4065996d7ceedd4dd4697"
+  integrity sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==
+  dependencies:
+    rimraf "~2.6.2"
 
 terser@^3.7.5:
   version "3.10.0"
@@ -8445,18 +8347,13 @@ to-utf8@0.0.1:
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
   integrity sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=
 
-tough-cookie@>=2.3.3, tough-cookie@~2.4.3:
+tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-"traverse@>=0.3.0 <0.4":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
-  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
 
 tree-sync@^1.2.2:
   version "1.2.2"
@@ -8616,14 +8513,6 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
-
-unzip-stream@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/unzip-stream/-/unzip-stream-0.3.0.tgz#c30c054cd6b0d64b13a23cd3ece911eb0b2b52d8"
-  integrity sha512-NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==
-  dependencies:
-    binary "^0.3.0"
-    mkdirp "^0.5.1"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -8901,11 +8790,6 @@ xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Upgrades to the latest version of Elm adding a configuration option to work around requirement for `main` values in compilation targets.

- README updated to document the new setting and its purpose
- Drops support for older unsupported ember and node versions
- Updates the travis build and test code to fix some lingering issues
- Updates elm dependencies (elm/browser, etc.)
