### PR TITLE
Bug Fix - Ember serve fails to incorporate changes outside of `includePaths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ export default Ember.Controller.extend({
 ### main
 
 `ember-elm` requires your elm files w/ `main` values to be defined in a separate directory 
-than the rest of your elm code.  By default this is set to `/elm-modules/Main/`.  Those files 
-can then be used to import other elm files living outside of `/elm-modules/Main/`.
+than the rest of your elm code.  By default this is set to `/elm-modules/Main/`, which will match everything 
+in `<your app>/elm-module/Main/`.  Those files can then be used to import other elm files living outside of `/elm-modules/Main/`.
 
 To specify a different location, override `mainDirs` in `ember-cli-build.js` like:
 
 ```js
 elm: {
-  mainDirs: ['app/elm-modules/AnotherMain']
+  mainDirs: ['/elm-modules/AnotherMain']
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,27 +159,15 @@ export default Ember.Controller.extend({
 
 ### main
 
-Compilation of Elm files in version 0.19.1 requires a `main` value for all files
-passed to `elm-make`.
+`ember-elm` requires your elm files w/ `main` values to be defined in a separate directory 
+than the rest of your elm code.  By default this is set to `/elm-modules/Main/`.  Those files 
+can then be used to import other elm files living outside of `/elm-modules/Main/`.
 
-```
--- NO MAIN ---------------------------------------------------------------------
-
-When producing a JS file, I require that given files all have `main` values.
-That way functions like Elm.CSS.ChatConversationStyle.init() are definitely
-defined in the resulting file. I am missing `main` values in:
-
-... cut for brevity ...
-```
-
-To target only files that have `main` values, use the ember-elm `includePaths`
-configuration option in `ember-cli-build.js` to limit compliation to only
-safe directories.  The elm compiler will handle including any other module
-dependencies.
+To specify a different location, override `mainDirs` in `ember-cli-build.js` like:
 
 ```js
 elm: {
-  includePaths: ['app/elm-modules/Main']
+  mainDirs: ['app/elm-modules/AnotherMain']
 }
 ```
 

--- a/broccoli-elm/index.js
+++ b/broccoli-elm/index.js
@@ -31,7 +31,7 @@ module.exports = class ElmCompiler extends CachingWriter {
       {
         debug: useDebug,
         optimize: optimize,
-	mainDirs: mainDirs
+        mainDirs: mainDirs
       },
       optionDefaults,
       options

--- a/broccoli-elm/index.js
+++ b/broccoli-elm/index.js
@@ -26,10 +26,12 @@ module.exports = class ElmCompiler extends CachingWriter {
     this.destDir = destDir;
     let useDebug = process.env.EMBER_ENV != "production";
     let optimize = process.env.EMBER_ENV == "production";
+    let mainDirs = ['/elm-modules/Main/'];
     this.options = Object.assign(
       {
         debug: useDebug,
-        optimize: optimize
+        optimize: optimize,
+	mainDirs: mainDirs
       },
       optionDefaults,
       options
@@ -45,12 +47,19 @@ module.exports = class ElmCompiler extends CachingWriter {
   build() {
     let options = Object.assign({}, this.options);
     let files = this.listFiles();
-    if (!files.length) {
+    let mainFiles = files.filter(file => 
+            options.mainDirs.some(mainDir =>
+              file.includes(mainDir)
+            ));
+
+    if (!mainFiles.length) {
       // Nothing to build
       return;
     }
 
-    return compileToString(files, options)
+    // mainDirs is consumed by ember-elm, and shouldn't be sent along to node-elm-compiler
+    delete options.mainDirs;
+    return compileToString(mainFiles, options)
       .then(data => {
         // elm-make output
         let jsStr = data.toString();

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,7 @@ const EmberAddon = require("ember-cli/lib/broccoli/ember-addon");
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     elm: {
-      includePaths: ['tests/dummy/app/elm-modules/Main']
+      mainDirs: ['/elm-modules/Main/']
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
-    "elm": "^0.19.1-3",
+    "elm": "^0.19.1-5",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.4.0",
     "ember-cli-app-version": "^2.0.0",


### PR DESCRIPTION
This addresses a regression caused by the 19.1 upgrade.  

## To Reproduce:
1. `ember serve`
2. open `Hello/Label.elm` - update text from `Send` to `New Send`
3. open browser to dummy app

### Expected
See send button w/ text `New Send`

### Actual
See send button w/ text `Send`

Making any update to `Main/Chat.elm` and saving then results in `New Send` coming through.


### Solve
It seems using `includePaths` made it so that the build output was considered a result of only the files within `includePaths`, when the nature of elm compilation means the build output needs to take into account changes to files outside of `includePaths`.

This fix opts instead to use our own `mainDirs` option to whitelist a set of paths for Elm compilation inclusion, so that ember/broccoli still considers all elm files to be incorporated into the output asset.

I've tested this out in our larger ember/elm project, and it works well there too.

To get this fix working in your project, make sure you remove `includePaths` from your `ember-cli-build.js`